### PR TITLE
add naToValue arg

### DIFF
--- a/R/app_alphaDiv.R
+++ b/R/app_alphaDiv.R
@@ -13,7 +13,7 @@
 #' @import veupathUtils
 #' @import data.table
 #' @export
-alphaDiv <- function(df, recordIdColumn, method = c('shannon','simpson','evenness'), naToZero = c(FALSE, TRUE), verbose = c(TRUE, FALSE)) {
+alphaDiv <- function(df, recordIdColumn, method = c('shannon','simpson','evenness'), naToZero = c(TRUE, FALSE), verbose = c(TRUE, FALSE)) {
 
     # Initialize and check inputs
     method <- veupathUtils::matchArg(method)
@@ -25,7 +25,7 @@ alphaDiv <- function(df, recordIdColumn, method = c('shannon','simpson','evennes
     
     if (naToZero) {
       # Replace NA values with 0
-      veupathUtils::setNaToZero(df, cols = colnames(df[, -..recordIdColumn]))
+      veupathUtils::setNaToZero(df)
       veupathUtils::logWithTime("Replaced NAs with 0", verbose)
     }
 
@@ -124,7 +124,7 @@ alphaDiv <- function(df, recordIdColumn, method = c('shannon','simpson','evennes
 #' @export
 #' @import data.table
 #' @import veupathUtils
-alphaDivApp <- function(df, recordIdColumn, methods = c('shannon','simpson','evenness'), naToZero = c(FALSE, TRUE), verbose = c(TRUE, FALSE)) {
+alphaDivApp <- function(df, recordIdColumn, methods = c('shannon','simpson','evenness'), naToZero = c(TRUE, FALSE), verbose = c(TRUE, FALSE)) {
 
     naToZero <- veupathUtils::matchArg(naToZero)
     verbose <- veupathUtils::matchArg(verbose)

--- a/R/app_betaDiv.R
+++ b/R/app_betaDiv.R
@@ -6,7 +6,7 @@
 #' @param recordIdColumn string defining the name of the df column that specifies sample ids. Note, all other columns must be numeric and will be treated as abundance values.
 #' @param method string defining the the beta diversity dissimilarity method. Accepted values are 'bray','jaccard', and 'jsd'
 #' @param k integer determining the number of pcoa axes to return
-#' @param naToValue number or NULL. If a number, any NA found in the numeric columns of df will be replaced with this number.
+#' @param naToZero boolean indicating if NAs in numeric columns should be replaced with 0
 #' @param verbose boolean indicating if timed logging is desired
 #' @return data.table with a column for the recordIdColumn, as well as columns corresponding to pcoa axes.
 #' @importFrom Rcpp sourceCpp
@@ -21,20 +21,21 @@ betaDiv <- function(df,
                     recordIdColumn,
                     method = c('bray','jaccard','jsd'),
                     k = 2,
-                    naToValue = NULL,
+                    naToZero = c(FALSE, TRUE),
                     verbose = c(TRUE, FALSE)) {
 
     # Initialize and check inputs
     method <- veupathUtils::matchArg(method)
+    naToZero <- veupathUtils::matchArg(naToZero)
     verbose <- veupathUtils::matchArg(verbose)
 
     computeMessage <- ''
     veupathUtils::logWithTime(paste("Received df table with", nrow(df), "samples and", (ncol(df)-1), "taxa."), verbose)
 
-    # Replace NA values if naToValue is given
-    if (!is.null(naToValue)) {
-      veupathUtils::setNaToValue(df, value = naToValue, cols = colnames(df[, -..recordIdColumn]))
-      veupathUtils::logWithTime(paste("Replaced NAs with", naToValue), verbose)
+    if (naToZero) {
+      # Replace NA values with 0
+      veupathUtils::setNaToZero(df, cols = colnames(df[, -..recordIdColumn]))
+      veupathUtils::logWithTime("Replaced NAs with 0", verbose)
     }
 
     # Compute beta diversity using given dissimilarity method
@@ -75,7 +76,7 @@ betaDiv <- function(df,
                                      'computedVariableMetadata' = computedVariableMetadata)
 
       veupathUtils::setAttrFromList(dt, attr, removeExtraAttrs = F)
-      veupathUtils::logWithTime(paste('Beta diversity computation FAILED with parameters recordIdColumn=', recordIdColumn, ', method=', method, ', k=', k , ', verbose =', verbose), verbose)
+      veupathUtils::logWithTime(paste('Beta diversity computation FAILED with parameters recordIdColumn=', recordIdColumn, ', method=', method, ', k=', k , ', naToZero = ', naToZero, ', verbose =', verbose), verbose)
       
       return(dt)
       
@@ -142,7 +143,7 @@ betaDiv <- function(df,
 #' @param recordIdColumn string defining the name of the df column that specifies sample ids. Note, all other columns must be numeric and will be treated as abundance values.
 #' @param methods vector of strings defining the the beta diversity dissimilarity methods to use. Must be a subset of c('bray','jaccard','jsd').
 #' @param k integer determining the number of pcoa dimensions to return
-#' @param naToValue number or NULL. If a number, any NA found in the numeric columns of df will be replaced with this number.
+#' @param naToZero boolean indicating if NAs in numeric columns should be replaced with 0
 #' @param verbose boolean indicating if timed logging is desired
 #' @return name of a json file containing a list of data.tables, one for each method specified in methods. Each data.table contains a column for the recordIdColumn, as well as columns corresponding to pcoa axes.
 #' @export
@@ -150,11 +151,12 @@ betaDivApp <- function(df,
                       recordIdColumn,
                       methods = c('bray','jaccard','jsd'),
                       k = 2,
-                      naToValue = NULL,
+                      naToZero = c(FALSE, TRUE),
                       verbose = c(TRUE, FALSE)) {
 
     df <- data.table::setDT(df)
 
+    naToZero <- veupathUtils::matchArg(naToZero)
     verbose <- veupathUtils::matchArg(verbose)
     
     # Allow any number of methods to be inputted
@@ -178,7 +180,7 @@ betaDivApp <- function(df,
       stop("All entities must be identical")
     }
 
-    appResults <- lapply(methods, betaDiv, df=df, recordIdColumn=recordIdColumn, k=k, naToValue=naToValue, verbose=verbose)
+    appResults <- lapply(methods, betaDiv, df=df, recordIdColumn=recordIdColumn, k=k, naToZero=naToZero, verbose=verbose)
     
 
     # Write to json file

--- a/R/app_betaDiv.R
+++ b/R/app_betaDiv.R
@@ -21,7 +21,7 @@ betaDiv <- function(df,
                     recordIdColumn,
                     method = c('bray','jaccard','jsd'),
                     k = 2,
-                    naToZero = c(FALSE, TRUE),
+                    naToZero = c(TRUE, FALSE),
                     verbose = c(TRUE, FALSE)) {
 
     # Initialize and check inputs
@@ -34,7 +34,7 @@ betaDiv <- function(df,
 
     if (naToZero) {
       # Replace NA values with 0
-      veupathUtils::setNaToZero(df, cols = colnames(df[, -..recordIdColumn]))
+      veupathUtils::setNaToZero(df)
       veupathUtils::logWithTime("Replaced NAs with 0", verbose)
     }
 
@@ -151,7 +151,7 @@ betaDivApp <- function(df,
                       recordIdColumn,
                       methods = c('bray','jaccard','jsd'),
                       k = 2,
-                      naToZero = c(FALSE, TRUE),
+                      naToZero = c(TRUE, FALSE),
                       verbose = c(TRUE, FALSE)) {
 
     df <- data.table::setDT(df)

--- a/R/app_betaDiv.R
+++ b/R/app_betaDiv.R
@@ -154,8 +154,6 @@ betaDivApp <- function(df,
                       naToZero = c(TRUE, FALSE),
                       verbose = c(TRUE, FALSE)) {
 
-    df <- data.table::setDT(df)
-
     naToZero <- veupathUtils::matchArg(naToZero)
     verbose <- veupathUtils::matchArg(verbose)
     

--- a/R/app_rankedAbundance.R
+++ b/R/app_rankedAbundance.R
@@ -6,12 +6,13 @@
 #' @param recordIdColumn string defining the name of the df column that specifies sample ids. Note, all other columns must be numeric and will be treated as abundance values.
 #' @param method string defining the ranking strategy by which to order the taxa. Accepted values are 'median','max','q3',and 'variance'. Note that taxa that return a value of 0 for a given method will not be included in the results.
 #' @param cutoff integer indicating the maximium number of taxa to be kept after ranking.
+#' @param naToValue number or NULL. If a number, any NA found in the numeric columns of df will be replaced with this number.
 #' @param verbose boolean indicating if timed logging is desired
 #' @return data.table with columns recordIdColumn, followed by the top taxa as ranked by the given method, with no more taxa columns than specified by the cutoff argument.
 #' @import veupathUtils
 #' @import data.table
 #' @export
-rankedAbundance <- function(df, recordIdColumn, method = c('median','max','q3','variance'), cutoff=10, verbose = c(TRUE, FALSE)) {
+rankedAbundance <- function(df, recordIdColumn, method = c('median','max','q3','variance'), cutoff=10, naToValue=NULL, verbose = c(TRUE, FALSE)) {
 
     # Initialize and check inputs
     method <- veupathUtils::matchArg(method)
@@ -20,8 +21,14 @@ rankedAbundance <- function(df, recordIdColumn, method = c('median','max','q3','
     computeMessage <- ''
     veupathUtils::logWithTime(paste("Received df table with", nrow(df), "samples and", (ncol(df)-1), "taxa."), verbose)
 
+    # Replace NA values if naToValue is given
+    if (!is.null(naToValue)) {
+      veupathUtils::setNaToValue(df, value = naToValue, cols = colnames(df[, -..recordIdColumn]))
+      veupathUtils::logWithTime(paste("Replaced NAs with", naToValue), verbose)
+    }
+
     # Reshape back to sample, taxonomicLevel, abundance
-    formattedDT <- data.table::melt(df, measure.vars=colnames(df)[-1], variable.factor=F, variable.name='TaxonomicLevel', value.name="Abundance")
+    formattedDT <- data.table::melt(df, measure.vars=colnames(df[, -..recordIdColumn]), variable.factor=F, variable.name='TaxonomicLevel', value.name="Abundance")
 
     rankedTaxa <- rankTaxa(formattedDT, method)
 
@@ -74,11 +81,12 @@ rankedAbundance <- function(df, recordIdColumn, method = c('median','max','q3','
 #' @param recordIdColumn string defining the name of the df column that specifies sample ids. Note, all other columns must be numeric and will be treated as abundance values.
 #' @param methods vector of strings indicating ranking methods to use. Must be a subset of c('median','max','q3','variance').
 #' @param cutoff integer indicating the maximium number of taxa to be kept after ranking.
+#' @param naToValue number or NULL. If a number, any NA found in the numeric columns of df will be replaced with this number.
 #' @param verbose boolean indicating if timed logging is desired.
 #' @return name of a json file containing a list of data.tables, one for each method specified in methods. Each data.table contains a column for the recordIdColumn, top taxa columns, and an attribute "parameters" that records the method used.
 #' @import veupathUtils
 #' @export
-rankedAbundanceApp <- function(df, recordIdColumn, methods=c('median','max','q3','variance'), cutoff=10, verbose=c(TRUE, FALSE)) {
+rankedAbundanceApp <- function(df, recordIdColumn, methods=c('median','max','q3','variance'), cutoff=10, naToValue=NULL, verbose=c(TRUE, FALSE)) {
 
     verbose <- veupathUtils::matchArg(verbose)
 
@@ -103,7 +111,7 @@ rankedAbundanceApp <- function(df, recordIdColumn, methods=c('median','max','q3'
       stop("All entities must be identical")
     }
 
-    appResults <- lapply(methods, rankedAbundance, df=df, recordIdColumn=recordIdColumn, cutoff=cutoff, verbose=verbose)
+    appResults <- lapply(methods, rankedAbundance, df=df, recordIdColumn=recordIdColumn, cutoff=cutoff, naToValue=naToValue, verbose=verbose)
 
     # Write to json file
     # outFileName <- writeAppResultsToJson(appResults, recordIdColumn = recordIdColumn, 'rankedAbundance', verbose = verbose)

--- a/R/app_rankedAbundance.R
+++ b/R/app_rankedAbundance.R
@@ -12,7 +12,7 @@
 #' @import veupathUtils
 #' @import data.table
 #' @export
-rankedAbundance <- function(df, recordIdColumn, method = c('median','max','q3','variance'), cutoff=10, naToZero=c(FALSE, TRUE), verbose = c(TRUE, FALSE)) {
+rankedAbundance <- function(df, recordIdColumn, method = c('median','max','q3','variance'), cutoff=10, naToZero=c(TRUE, FALSE), verbose = c(TRUE, FALSE)) {
 
     # Initialize and check inputs
     method <- veupathUtils::matchArg(method)
@@ -24,7 +24,7 @@ rankedAbundance <- function(df, recordIdColumn, method = c('median','max','q3','
 
     if (naToZero) {
       # Replace NA values with 0
-      veupathUtils::setNaToZero(df, cols = colnames(df[, -..recordIdColumn]))
+      veupathUtils::setNaToZero(df)
       veupathUtils::logWithTime("Replaced NAs with 0", verbose)
     }
 
@@ -87,7 +87,7 @@ rankedAbundance <- function(df, recordIdColumn, method = c('median','max','q3','
 #' @return name of a json file containing a list of data.tables, one for each method specified in methods. Each data.table contains a column for the recordIdColumn, top taxa columns, and an attribute "parameters" that records the method used.
 #' @import veupathUtils
 #' @export
-rankedAbundanceApp <- function(df, recordIdColumn, methods=c('median','max','q3','variance'), cutoff=10, naToZero=c(FALSE, TRUE), verbose=c(TRUE, FALSE)) {
+rankedAbundanceApp <- function(df, recordIdColumn, methods=c('median','max','q3','variance'), cutoff=10, naToZero=c(TRUE, FALSE), verbose=c(TRUE, FALSE)) {
 
     naToZero <- veupathUtils::matchArg(naToZero)
     verbose <- veupathUtils::matchArg(verbose)

--- a/R/app_rankedAbundance.R
+++ b/R/app_rankedAbundance.R
@@ -6,25 +6,26 @@
 #' @param recordIdColumn string defining the name of the df column that specifies sample ids. Note, all other columns must be numeric and will be treated as abundance values.
 #' @param method string defining the ranking strategy by which to order the taxa. Accepted values are 'median','max','q3',and 'variance'. Note that taxa that return a value of 0 for a given method will not be included in the results.
 #' @param cutoff integer indicating the maximium number of taxa to be kept after ranking.
-#' @param naToValue number or NULL. If a number, any NA found in the numeric columns of df will be replaced with this number.
+#' @param naToZero boolean indicating if NAs in numeric columns should be replaced with 0
 #' @param verbose boolean indicating if timed logging is desired
 #' @return data.table with columns recordIdColumn, followed by the top taxa as ranked by the given method, with no more taxa columns than specified by the cutoff argument.
 #' @import veupathUtils
 #' @import data.table
 #' @export
-rankedAbundance <- function(df, recordIdColumn, method = c('median','max','q3','variance'), cutoff=10, naToValue=NULL, verbose = c(TRUE, FALSE)) {
+rankedAbundance <- function(df, recordIdColumn, method = c('median','max','q3','variance'), cutoff=10, naToZero=c(FALSE, TRUE), verbose = c(TRUE, FALSE)) {
 
     # Initialize and check inputs
     method <- veupathUtils::matchArg(method)
+    naToZero <- veupathUtils::matchArg(naToZero)
     verbose <- veupathUtils::matchArg(verbose)
 
     computeMessage <- ''
     veupathUtils::logWithTime(paste("Received df table with", nrow(df), "samples and", (ncol(df)-1), "taxa."), verbose)
 
-    # Replace NA values if naToValue is given
-    if (!is.null(naToValue)) {
-      veupathUtils::setNaToValue(df, value = naToValue, cols = colnames(df[, -..recordIdColumn]))
-      veupathUtils::logWithTime(paste("Replaced NAs with", naToValue), verbose)
+    if (naToZero) {
+      # Replace NA values with 0
+      veupathUtils::setNaToZero(df, cols = colnames(df[, -..recordIdColumn]))
+      veupathUtils::logWithTime("Replaced NAs with 0", verbose)
     }
 
     # Reshape back to sample, taxonomicLevel, abundance
@@ -68,7 +69,7 @@ rankedAbundance <- function(df, recordIdColumn, method = c('median','max','q3','
     
     veupathUtils::setAttrFromList(dt, attr, removeExtraAttrs = F)
 
-    veupathUtils::logWithTime(paste('Ranked abundance computation completed with parameters recordIdColumn=', recordIdColumn, ', method =', method, ', cutoff =', cutoff, ', verbose =', verbose), verbose)
+    veupathUtils::logWithTime(paste('Ranked abundance computation completed with parameters recordIdColumn=', recordIdColumn, ', method =', method, ', cutoff =', cutoff, ', naToZero = ', naToZero, ', verbose =', verbose), verbose)
 
     return(dt)
 }
@@ -81,13 +82,14 @@ rankedAbundance <- function(df, recordIdColumn, method = c('median','max','q3','
 #' @param recordIdColumn string defining the name of the df column that specifies sample ids. Note, all other columns must be numeric and will be treated as abundance values.
 #' @param methods vector of strings indicating ranking methods to use. Must be a subset of c('median','max','q3','variance').
 #' @param cutoff integer indicating the maximium number of taxa to be kept after ranking.
-#' @param naToValue number or NULL. If a number, any NA found in the numeric columns of df will be replaced with this number.
+#' @param naToZero boolean indicating if NAs in numeric columns should be replaced with 0
 #' @param verbose boolean indicating if timed logging is desired.
 #' @return name of a json file containing a list of data.tables, one for each method specified in methods. Each data.table contains a column for the recordIdColumn, top taxa columns, and an attribute "parameters" that records the method used.
 #' @import veupathUtils
 #' @export
-rankedAbundanceApp <- function(df, recordIdColumn, methods=c('median','max','q3','variance'), cutoff=10, naToValue=NULL, verbose=c(TRUE, FALSE)) {
+rankedAbundanceApp <- function(df, recordIdColumn, methods=c('median','max','q3','variance'), cutoff=10, naToZero=c(FALSE, TRUE), verbose=c(TRUE, FALSE)) {
 
+    naToZero <- veupathUtils::matchArg(naToZero)
     verbose <- veupathUtils::matchArg(verbose)
 
     allMethods <- c('median','max','q3','variance')
@@ -111,7 +113,7 @@ rankedAbundanceApp <- function(df, recordIdColumn, methods=c('median','max','q3'
       stop("All entities must be identical")
     }
 
-    appResults <- lapply(methods, rankedAbundance, df=df, recordIdColumn=recordIdColumn, cutoff=cutoff, naToValue=naToValue, verbose=verbose)
+    appResults <- lapply(methods, rankedAbundance, df=df, recordIdColumn=recordIdColumn, cutoff=cutoff, naToZero=naToZero, verbose=verbose)
 
     # Write to json file
     # outFileName <- writeAppResultsToJson(appResults, recordIdColumn = recordIdColumn, 'rankedAbundance', verbose = verbose)

--- a/man/alphaDiv.Rd
+++ b/man/alphaDiv.Rd
@@ -8,7 +8,7 @@ alphaDiv(
   df,
   recordIdColumn,
   method = c("shannon", "simpson", "evenness"),
-  naToValue = NULL,
+  naToZero = c(FALSE, TRUE),
   verbose = c(TRUE, FALSE)
 )
 }
@@ -19,7 +19,7 @@ alphaDiv(
 
 \item{method}{string defining the the alpha diversity method. Accepted values are 'shannon','simpson', and 'evenness'}
 
-\item{naToValue}{number or NULL. If a number, any NA found in the numeric columns of df will be replaced with this number.}
+\item{naToZero}{boolean indicating if NAs in numeric columns should be replaced with 0}
 
 \item{verbose}{boolean indicating if timed logging is desired}
 }

--- a/man/alphaDiv.Rd
+++ b/man/alphaDiv.Rd
@@ -8,6 +8,7 @@ alphaDiv(
   df,
   recordIdColumn,
   method = c("shannon", "simpson", "evenness"),
+  naToValue = NULL,
   verbose = c(TRUE, FALSE)
 )
 }
@@ -17,6 +18,8 @@ alphaDiv(
 \item{recordIdColumn}{string defining the name of the df column that specifies record ids. Note, all other columns must be numeric and will be treated as abundance values.}
 
 \item{method}{string defining the the alpha diversity method. Accepted values are 'shannon','simpson', and 'evenness'}
+
+\item{naToValue}{number or NULL. If a number, any NA found in the numeric columns of df will be replaced with this number.}
 
 \item{verbose}{boolean indicating if timed logging is desired}
 }

--- a/man/alphaDiv.Rd
+++ b/man/alphaDiv.Rd
@@ -8,7 +8,7 @@ alphaDiv(
   df,
   recordIdColumn,
   method = c("shannon", "simpson", "evenness"),
-  naToZero = c(FALSE, TRUE),
+  naToZero = c(TRUE, FALSE),
   verbose = c(TRUE, FALSE)
 )
 }

--- a/man/alphaDivApp.Rd
+++ b/man/alphaDivApp.Rd
@@ -8,6 +8,7 @@ alphaDivApp(
   df,
   recordIdColumn,
   methods = c("shannon", "simpson", "evenness"),
+  naToValue = NULL,
   verbose = c(TRUE, FALSE)
 )
 }
@@ -17,6 +18,8 @@ alphaDivApp(
 \item{recordIdColumn}{string defining the name of the df column that specifies sample ids. Note, all other columns must be numeric and will be treated as abundance values.}
 
 \item{methods}{vector of strings defining the the beta diversity dissimilarity methods to use. Must be a subset of c('shannon','simpson','evenness').}
+
+\item{naToValue}{number or NULL. If a number, any NA found in the numeric columns of df will be replaced with this number.}
 
 \item{verbose}{boolean indicating if timed logging is desired}
 }

--- a/man/alphaDivApp.Rd
+++ b/man/alphaDivApp.Rd
@@ -8,7 +8,7 @@ alphaDivApp(
   df,
   recordIdColumn,
   methods = c("shannon", "simpson", "evenness"),
-  naToZero = c(FALSE, TRUE),
+  naToZero = c(TRUE, FALSE),
   verbose = c(TRUE, FALSE)
 )
 }

--- a/man/alphaDivApp.Rd
+++ b/man/alphaDivApp.Rd
@@ -8,7 +8,7 @@ alphaDivApp(
   df,
   recordIdColumn,
   methods = c("shannon", "simpson", "evenness"),
-  naToValue = NULL,
+  naToZero = c(FALSE, TRUE),
   verbose = c(TRUE, FALSE)
 )
 }
@@ -19,7 +19,7 @@ alphaDivApp(
 
 \item{methods}{vector of strings defining the the beta diversity dissimilarity methods to use. Must be a subset of c('shannon','simpson','evenness').}
 
-\item{naToValue}{number or NULL. If a number, any NA found in the numeric columns of df will be replaced with this number.}
+\item{naToZero}{boolean indicating if NAs in numeric columns should be replaced with 0}
 
 \item{verbose}{boolean indicating if timed logging is desired}
 }

--- a/man/betaDiv.Rd
+++ b/man/betaDiv.Rd
@@ -9,7 +9,7 @@ betaDiv(
   recordIdColumn,
   method = c("bray", "jaccard", "jsd"),
   k = 2,
-  naToZero = c(FALSE, TRUE),
+  naToZero = c(TRUE, FALSE),
   verbose = c(TRUE, FALSE)
 )
 }

--- a/man/betaDiv.Rd
+++ b/man/betaDiv.Rd
@@ -9,6 +9,7 @@ betaDiv(
   recordIdColumn,
   method = c("bray", "jaccard", "jsd"),
   k = 2,
+  naToValue = NULL,
   verbose = c(TRUE, FALSE)
 )
 }
@@ -20,6 +21,8 @@ betaDiv(
 \item{method}{string defining the the beta diversity dissimilarity method. Accepted values are 'bray','jaccard', and 'jsd'}
 
 \item{k}{integer determining the number of pcoa axes to return}
+
+\item{naToValue}{number or NULL. If a number, any NA found in the numeric columns of df will be replaced with this number.}
 
 \item{verbose}{boolean indicating if timed logging is desired}
 }

--- a/man/betaDiv.Rd
+++ b/man/betaDiv.Rd
@@ -9,7 +9,7 @@ betaDiv(
   recordIdColumn,
   method = c("bray", "jaccard", "jsd"),
   k = 2,
-  naToValue = NULL,
+  naToZero = c(FALSE, TRUE),
   verbose = c(TRUE, FALSE)
 )
 }
@@ -22,7 +22,7 @@ betaDiv(
 
 \item{k}{integer determining the number of pcoa axes to return}
 
-\item{naToValue}{number or NULL. If a number, any NA found in the numeric columns of df will be replaced with this number.}
+\item{naToZero}{boolean indicating if NAs in numeric columns should be replaced with 0}
 
 \item{verbose}{boolean indicating if timed logging is desired}
 }

--- a/man/betaDivApp.Rd
+++ b/man/betaDivApp.Rd
@@ -9,7 +9,7 @@ betaDivApp(
   recordIdColumn,
   methods = c("bray", "jaccard", "jsd"),
   k = 2,
-  naToZero = c(FALSE, TRUE),
+  naToZero = c(TRUE, FALSE),
   verbose = c(TRUE, FALSE)
 )
 }

--- a/man/betaDivApp.Rd
+++ b/man/betaDivApp.Rd
@@ -9,7 +9,7 @@ betaDivApp(
   recordIdColumn,
   methods = c("bray", "jaccard", "jsd"),
   k = 2,
-  naToValue = NULL,
+  naToZero = c(FALSE, TRUE),
   verbose = c(TRUE, FALSE)
 )
 }
@@ -22,7 +22,7 @@ betaDivApp(
 
 \item{k}{integer determining the number of pcoa dimensions to return}
 
-\item{naToValue}{number or NULL. If a number, any NA found in the numeric columns of df will be replaced with this number.}
+\item{naToZero}{boolean indicating if NAs in numeric columns should be replaced with 0}
 
 \item{verbose}{boolean indicating if timed logging is desired}
 }

--- a/man/betaDivApp.Rd
+++ b/man/betaDivApp.Rd
@@ -9,6 +9,7 @@ betaDivApp(
   recordIdColumn,
   methods = c("bray", "jaccard", "jsd"),
   k = 2,
+  naToValue = NULL,
   verbose = c(TRUE, FALSE)
 )
 }
@@ -20,6 +21,8 @@ betaDivApp(
 \item{methods}{vector of strings defining the the beta diversity dissimilarity methods to use. Must be a subset of c('bray','jaccard','jsd').}
 
 \item{k}{integer determining the number of pcoa dimensions to return}
+
+\item{naToValue}{number or NULL. If a number, any NA found in the numeric columns of df will be replaced with this number.}
 
 \item{verbose}{boolean indicating if timed logging is desired}
 }

--- a/man/rankedAbundance.Rd
+++ b/man/rankedAbundance.Rd
@@ -9,7 +9,7 @@ rankedAbundance(
   recordIdColumn,
   method = c("median", "max", "q3", "variance"),
   cutoff = 10,
-  naToValue = NULL,
+  naToZero = c(FALSE, TRUE),
   verbose = c(TRUE, FALSE)
 )
 }
@@ -22,7 +22,7 @@ rankedAbundance(
 
 \item{cutoff}{integer indicating the maximium number of taxa to be kept after ranking.}
 
-\item{naToValue}{number or NULL. If a number, any NA found in the numeric columns of df will be replaced with this number.}
+\item{naToZero}{boolean indicating if NAs in numeric columns should be replaced with 0}
 
 \item{verbose}{boolean indicating if timed logging is desired}
 }

--- a/man/rankedAbundance.Rd
+++ b/man/rankedAbundance.Rd
@@ -9,7 +9,7 @@ rankedAbundance(
   recordIdColumn,
   method = c("median", "max", "q3", "variance"),
   cutoff = 10,
-  naToZero = c(FALSE, TRUE),
+  naToZero = c(TRUE, FALSE),
   verbose = c(TRUE, FALSE)
 )
 }

--- a/man/rankedAbundance.Rd
+++ b/man/rankedAbundance.Rd
@@ -9,6 +9,7 @@ rankedAbundance(
   recordIdColumn,
   method = c("median", "max", "q3", "variance"),
   cutoff = 10,
+  naToValue = NULL,
   verbose = c(TRUE, FALSE)
 )
 }
@@ -20,6 +21,8 @@ rankedAbundance(
 \item{method}{string defining the ranking strategy by which to order the taxa. Accepted values are 'median','max','q3',and 'variance'. Note that taxa that return a value of 0 for a given method will not be included in the results.}
 
 \item{cutoff}{integer indicating the maximium number of taxa to be kept after ranking.}
+
+\item{naToValue}{number or NULL. If a number, any NA found in the numeric columns of df will be replaced with this number.}
 
 \item{verbose}{boolean indicating if timed logging is desired}
 }

--- a/man/rankedAbundanceApp.Rd
+++ b/man/rankedAbundanceApp.Rd
@@ -9,7 +9,7 @@ rankedAbundanceApp(
   recordIdColumn,
   methods = c("median", "max", "q3", "variance"),
   cutoff = 10,
-  naToValue = NULL,
+  naToZero = c(FALSE, TRUE),
   verbose = c(TRUE, FALSE)
 )
 }
@@ -22,7 +22,7 @@ rankedAbundanceApp(
 
 \item{cutoff}{integer indicating the maximium number of taxa to be kept after ranking.}
 
-\item{naToValue}{number or NULL. If a number, any NA found in the numeric columns of df will be replaced with this number.}
+\item{naToZero}{boolean indicating if NAs in numeric columns should be replaced with 0}
 
 \item{verbose}{boolean indicating if timed logging is desired.}
 }

--- a/man/rankedAbundanceApp.Rd
+++ b/man/rankedAbundanceApp.Rd
@@ -9,6 +9,7 @@ rankedAbundanceApp(
   recordIdColumn,
   methods = c("median", "max", "q3", "variance"),
   cutoff = 10,
+  naToValue = NULL,
   verbose = c(TRUE, FALSE)
 )
 }
@@ -20,6 +21,8 @@ rankedAbundanceApp(
 \item{methods}{vector of strings indicating ranking methods to use. Must be a subset of c('median','max','q3','variance').}
 
 \item{cutoff}{integer indicating the maximium number of taxa to be kept after ranking.}
+
+\item{naToValue}{number or NULL. If a number, any NA found in the numeric columns of df will be replaced with this number.}
 
 \item{verbose}{boolean indicating if timed logging is desired.}
 }

--- a/man/rankedAbundanceApp.Rd
+++ b/man/rankedAbundanceApp.Rd
@@ -9,7 +9,7 @@ rankedAbundanceApp(
   recordIdColumn,
   methods = c("median", "max", "q3", "variance"),
   cutoff = 10,
-  naToZero = c(FALSE, TRUE),
+  naToZero = c(TRUE, FALSE),
   verbose = c(TRUE, FALSE)
 )
 }

--- a/tests/testthat/test-alphaDiv.R
+++ b/tests/testthat/test-alphaDiv.R
@@ -24,9 +24,9 @@ test_that('alphaDiv returns a correctly formatted data.table', {
   # With NAs
   nNAs <- 20
   df[sample(1:nrow(df), size=nNAs, replace = F), 2] <- NA
-  dt <- alphaDiv(df, "entity.SampleID", method='shannon', verbose=F)  # vegan diversity sets output to NA if input has NA. See issue #187
+  dt <- alphaDiv(df, "entity.SampleID", method='shannon', naToZero = F, verbose=F)  # vegan diversity sets output to NA if input has NA. See issue #187
   expect_equal(sum(is.na(dt)), nNAs)
-  dt <- alphaDiv(df, "entity.SampleID", method='shannon', naToZero=T, verbose=F)
+  dt <- alphaDiv(df, "entity.SampleID", method='shannon', verbose=F)
   expect_equal(sum(is.na(dt)), 0)
   expect_equal(nrow(dt), nrow(df))
   expect_s3_class(dt, 'data.table')
@@ -101,7 +101,7 @@ test_that("alphaDivApp produces an appropriately structured list of computations
   # With NAs
   nNAs <- 20
   df[sample(1:nrow(df), size=nNAs, replace = F), 2] <- NA
-  appResults <- alphaDivApp(df, "entity.SampleID", naToZero = T, verbose=F)
+  appResults <- alphaDivApp(df, "entity.SampleID", verbose=F)
   expect_equal(length(appResults), 3)
   expect_equal(unique(unlist(lapply(appResults,names))), c('entity.SampleID','entity.alphaDiversity'))
   expect_equal(unique(unlist(lapply(appResults, class))), c('data.table','data.frame'))

--- a/tests/testthat/test-alphaDiv.R
+++ b/tests/testthat/test-alphaDiv.R
@@ -26,7 +26,7 @@ test_that('alphaDiv returns a correctly formatted data.table', {
   df[sample(1:nrow(df), size=nNAs, replace = F), 2] <- NA
   dt <- alphaDiv(df, "entity.SampleID", method='shannon', verbose=F)  # vegan diversity sets output to NA if input has NA. See issue #187
   expect_equal(sum(is.na(dt)), nNAs)
-  dt <- alphaDiv(df, "entity.SampleID", method='shannon', naToValue=0, verbose=F)
+  dt <- alphaDiv(df, "entity.SampleID", method='shannon', naToZero=T, verbose=F)
   expect_equal(sum(is.na(dt)), 0)
   expect_equal(nrow(dt), nrow(df))
   expect_s3_class(dt, 'data.table')
@@ -101,7 +101,7 @@ test_that("alphaDivApp produces an appropriately structured list of computations
   # With NAs
   nNAs <- 20
   df[sample(1:nrow(df), size=nNAs, replace = F), 2] <- NA
-  appResults <- alphaDivApp(df, "entity.SampleID", naToValue = 0, verbose=F)
+  appResults <- alphaDivApp(df, "entity.SampleID", naToZero = T, verbose=F)
   expect_equal(length(appResults), 3)
   expect_equal(unique(unlist(lapply(appResults,names))), c('entity.SampleID','entity.alphaDiversity'))
   expect_equal(unique(unlist(lapply(appResults, class))), c('data.table','data.frame'))

--- a/tests/testthat/test-alphaDiv.R
+++ b/tests/testthat/test-alphaDiv.R
@@ -103,6 +103,7 @@ test_that("alphaDivApp produces an appropriately structured list of computations
   df[sample(1:nrow(df), size=nNAs, replace = F), 2] <- NA
   appResults <- alphaDivApp(df, "entity.SampleID", verbose=F)
   expect_equal(length(appResults), 3)
+  expect_true(all(unlist(lapply(appResults, function(x) {!is.na(x$entity.alphaDiversity)})))) # Should be no NAs
   expect_equal(unique(unlist(lapply(appResults,names))), c('entity.SampleID','entity.alphaDiversity'))
   expect_equal(unique(unlist(lapply(appResults, class))), c('data.table','data.frame'))
   expect_equal(unique(unlist(lapply(appResults, nrow))), nrow(df))
@@ -195,15 +196,16 @@ test_that("alphaDiv results are consistent", {
 test_that("alphaDiv fails gracefully", {
   
   df <- testOTU
-  df$entity.Abiotrophia <- -1
+  df$entity.Abiotrophia <- NA
   
-  dt <- alphaDiv(df, "entity.SampleID", method='evenness', verbose=T)
+  dt <- alphaDiv(df, "entity.SampleID", method='simpson', naToZero=F, verbose=T)
   expect_equal(nrow(dt), nrow(df))
   expect_s3_class(dt, 'data.table')
-  expect_equal(names(dt), 'entity.SampleID')
+  expect_equal(names(dt), c('entity.SampleID', 'entity.alphaDiversity'))
+  expect_true(all(is.na(dt[['entity.alphaDiversity']])))
   expect_equal(typeof(dt$entity.SampleID), c('character'))
   attr <- attributes(dt)
-  expect_equal(attr$computationDetails, "Error: alpha diversity evenness failed: input data must be non-negative")
+  # expect_equal(attr$computationDetails, "Error: alpha diversity evenness failed: input data must be non-negative")
   expect_equal(typeof(attr$parameters), 'character')
   expect_equal(typeof(attr$computedVariable$computedVariableDetails$variableId), 'character')
   expect_equal(typeof(attr$computedVariable$computedVariableDetails$entityId), 'character')

--- a/tests/testthat/test-betaDiv.R
+++ b/tests/testthat/test-betaDiv.R
@@ -21,6 +21,16 @@ test_that('betaDiv returns a correctly formatted data.table', {
   expect_equal(names(dt), c('entity.SampleID','entity.Axis1','entity.Axis2'))
   expect_equal(unname(unlist(lapply(dt, class))), c('character','numeric','numeric'))
   
+  # With NAs
+  nNAs <- 20
+  df[sample(1:nrow(df), size=nNAs, replace = F), 2] <- NA
+  expect_error(betaDiv(df, "entity.SampleID", method='jsd', verbose=F))  # all three methods err
+  dt <- betaDiv(df, "entity.SampleID", method='bray', naToValue=0, verbose=F) 
+  expect_equal(nrow(dt), nrow(df))
+  expect_s3_class(dt, 'data.table')
+  expect_equal(names(dt), c('entity.SampleID','entity.Axis1','entity.Axis2'))
+  expect_equal(unname(unlist(lapply(dt, class))), c('character','numeric','numeric'))
+  expect_true(sum(dt > 0) > 100)   # ensure output is not all 0
   
 })
 
@@ -81,7 +91,16 @@ test_that("betaDivApp produces an appropriately structured list of computations"
   expect_equal(unique(unlist(lapply(appResults,names))), c('entity.SampleID','entity.Axis1','entity.Axis2'))
   expect_equal(unique(unlist(lapply(appResults, class))), c('data.table','data.frame'))
   expect_equal(unique(unlist(lapply(appResults, nrow))), nrow(df))
-  
+
+  # With NAs
+  nNAs <- 20
+  df[sample(1:nrow(df), size=nNAs, replace = F), 2] <- NA
+  appResults <- betaDivApp(df, "entity.SampleID", methods = c('jaccard','bray'), naToValue = 0, verbose=F)
+  expect_equal(length(appResults), 2)
+  expect_equal(unique(unlist(lapply(appResults,names))), c('entity.SampleID','entity.Axis1','entity.Axis2'))
+  expect_equal(unique(unlist(lapply(appResults, class))), c('data.table','data.frame'))
+  expect_equal(unique(unlist(lapply(appResults, nrow))), nrow(df))
+
 })
 
 
@@ -153,7 +172,7 @@ test_that("betaDivApp output is correctly represented in json", {
   # computedVariableMetadata
   expect_equal(names(jsonList$computations$computedVariable$computedVariableMetadata), c('displayName'))
   expect_equal(jsonList$computations$computedVariable$computedVariableMetadata$displayName[[1]], c('Axis1 15.3%','Axis2 5.7%'))
-  
+
   
 })
 

--- a/tests/testthat/test-betaDiv.R
+++ b/tests/testthat/test-betaDiv.R
@@ -24,8 +24,8 @@ test_that('betaDiv returns a correctly formatted data.table', {
   # With NAs
   nNAs <- 20
   df[sample(1:nrow(df), size=nNAs, replace = F), 2] <- NA
-  expect_error(betaDiv(df, "entity.SampleID", method='jsd', verbose=F))  # all three methods err
-  dt <- betaDiv(df, "entity.SampleID", method='bray', naToZero=T, verbose=F) 
+  expect_error(betaDiv(df, "entity.SampleID", method='jsd', naToZero=F, verbose=F))  # all three methods err
+  dt <- betaDiv(df, "entity.SampleID", method='bray', verbose=F) 
   expect_equal(nrow(dt), nrow(df))
   expect_s3_class(dt, 'data.table')
   expect_equal(names(dt), c('entity.SampleID','entity.Axis1','entity.Axis2'))
@@ -95,7 +95,7 @@ test_that("betaDivApp produces an appropriately structured list of computations"
   # With NAs
   nNAs <- 20
   df[sample(1:nrow(df), size=nNAs, replace = F), 2] <- NA
-  appResults <- betaDivApp(df, "entity.SampleID", methods = c('jaccard','bray'), naToZero = T, verbose=F)
+  appResults <- betaDivApp(df, "entity.SampleID", methods = c('jaccard','bray'), verbose=F)
   expect_equal(length(appResults), 2)
   expect_equal(unique(unlist(lapply(appResults,names))), c('entity.SampleID','entity.Axis1','entity.Axis2'))
   expect_equal(unique(unlist(lapply(appResults, class))), c('data.table','data.frame'))
@@ -190,7 +190,7 @@ test_that("betaDiv fails gracefully", {
   df <- testOTU
   df$entity.Abiotrophia <- NA
   
-  dt <- betaDiv(df, "entity.SampleID", method='bray', verbose=T)
+  dt <- betaDiv(df, "entity.SampleID", method='bray', naToZero=F, verbose=T)
   expect_equal(nrow(dt), nrow(df))
   expect_s3_class(dt, 'data.table')
   expect_equal(names(dt), 'entity.SampleID')

--- a/tests/testthat/test-betaDiv.R
+++ b/tests/testthat/test-betaDiv.R
@@ -25,7 +25,7 @@ test_that('betaDiv returns a correctly formatted data.table', {
   nNAs <- 20
   df[sample(1:nrow(df), size=nNAs, replace = F), 2] <- NA
   expect_error(betaDiv(df, "entity.SampleID", method='jsd', verbose=F))  # all three methods err
-  dt <- betaDiv(df, "entity.SampleID", method='bray', naToValue=0, verbose=F) 
+  dt <- betaDiv(df, "entity.SampleID", method='bray', naToZero=T, verbose=F) 
   expect_equal(nrow(dt), nrow(df))
   expect_s3_class(dt, 'data.table')
   expect_equal(names(dt), c('entity.SampleID','entity.Axis1','entity.Axis2'))
@@ -95,7 +95,7 @@ test_that("betaDivApp produces an appropriately structured list of computations"
   # With NAs
   nNAs <- 20
   df[sample(1:nrow(df), size=nNAs, replace = F), 2] <- NA
-  appResults <- betaDivApp(df, "entity.SampleID", methods = c('jaccard','bray'), naToValue = 0, verbose=F)
+  appResults <- betaDivApp(df, "entity.SampleID", methods = c('jaccard','bray'), naToZero = T, verbose=F)
   expect_equal(length(appResults), 2)
   expect_equal(unique(unlist(lapply(appResults,names))), c('entity.SampleID','entity.Axis1','entity.Axis2'))
   expect_equal(unique(unlist(lapply(appResults, class))), c('data.table','data.frame'))

--- a/tests/testthat/test-rankedAbundance.R
+++ b/tests/testthat/test-rankedAbundance.R
@@ -30,8 +30,8 @@ test_that('rankedAbundance returns a correctly formatted data.table', {
   # With NAs
   nNAs <- 20
   df[sample(1:nrow(df), size=nNAs, replace = F), 2] <- NA
-  expect_error(rankedAbundance(df, "entity.SampleID", method='q3', verbose=F))
-  dt <- rankedAbundance(df, "entity.SampleID", method='q3', naToZero = T, verbose=F)
+  expect_error(rankedAbundance(df, "entity.SampleID", method='q3', naToZero=F, verbose=F))
+  dt <- rankedAbundance(df, "entity.SampleID", method='q3', verbose=F)
   expect_equal(nrow(dt), nrow(df))
   expect_s3_class(dt, 'data.table')
   expect_equal(names(dt), paste0('entity.',c('SampleID','Lactobacillus','Snodgrassella','Gilliamella','Frischella','Commensalibacter','unclassified Rhizobiaceae','Bifidobacterium','unclassified Mitochondria','unclassified Chloroplast','Bombella')))
@@ -126,7 +126,7 @@ test_that("rankedAbundanceApp produces an appropriately structured list of compu
   # With NAs
   nNAs <- 20
   df[sample(1:nrow(df), size=nNAs, replace = F), 2] <- NA
-  appResults <- rankedAbundanceApp(df, "entity.SampleID", methods = c('q3', 'median'), naToZero = T, verbose=F)
+  appResults <- rankedAbundanceApp(df, "entity.SampleID", methods = c('q3', 'median'), verbose=F)
   expect_equal(length(appResults), 2)
   expect_equal(unique(unlist(lapply(appResults, class))), c('data.table','data.frame'))
   expect_equal(unique(unlist(lapply(appResults, ncol))), 11)

--- a/tests/testthat/test-rankedAbundance.R
+++ b/tests/testthat/test-rankedAbundance.R
@@ -26,6 +26,18 @@ test_that('rankedAbundance returns a correctly formatted data.table', {
   expect_s3_class(dt, 'data.table')
   expect_equal(names(dt), paste0('entity.',c('SampleID','Lactobacillus','Snodgrassella','Gilliamella','Frischella','Commensalibacter','unclassified Rhizobiaceae','Bifidobacterium','unclassified Mitochondria','unclassified Chloroplast','Bombella')))
   expect_equal(unname(unlist(lapply(dt, class))), c('character', rep('numeric',10)))
+
+  # With NAs
+  nNAs <- 20
+  df[sample(1:nrow(df), size=nNAs, replace = F), 2] <- NA
+  expect_error(rankedAbundance(df, "entity.SampleID", method='q3', verbose=F))
+  dt <- rankedAbundance(df, "entity.SampleID", method='q3', naToValue = 0, verbose=F)
+  expect_equal(nrow(dt), nrow(df))
+  expect_s3_class(dt, 'data.table')
+  expect_equal(names(dt), paste0('entity.',c('SampleID','Lactobacillus','Snodgrassella','Gilliamella','Frischella','Commensalibacter','unclassified Rhizobiaceae','Bifidobacterium','unclassified Mitochondria','unclassified Chloroplast','Bombella')))
+  expect_equal(unname(unlist(lapply(dt, class))), c('character', rep('numeric',10)))
+  expect_equal(sum(dt > 0), 2847)   # ensure output is not all 0s.
+
   
 })
 
@@ -106,6 +118,15 @@ test_that("rankedAbundanceApp produces an appropriately structured list of compu
   
   # Test using a subset of methods
   appResults <- rankedAbundanceApp(df, "entity.SampleID", methods = c('q3', 'median'), verbose=F)
+  expect_equal(length(appResults), 2)
+  expect_equal(unique(unlist(lapply(appResults, class))), c('data.table','data.frame'))
+  expect_equal(unique(unlist(lapply(appResults, ncol))), 11)
+  expect_equal(unique(unlist(lapply(appResults, nrow))), nrow(df))
+
+  # With NAs
+  nNAs <- 20
+  df[sample(1:nrow(df), size=nNAs, replace = F), 2] <- NA
+  appResults <- rankedAbundanceApp(df, "entity.SampleID", methods = c('q3', 'median'), naToValue = 0, verbose=F)
   expect_equal(length(appResults), 2)
   expect_equal(unique(unlist(lapply(appResults, class))), c('data.table','data.frame'))
   expect_equal(unique(unlist(lapply(appResults, ncol))), 11)

--- a/tests/testthat/test-rankedAbundance.R
+++ b/tests/testthat/test-rankedAbundance.R
@@ -31,7 +31,7 @@ test_that('rankedAbundance returns a correctly formatted data.table', {
   nNAs <- 20
   df[sample(1:nrow(df), size=nNAs, replace = F), 2] <- NA
   expect_error(rankedAbundance(df, "entity.SampleID", method='q3', verbose=F))
-  dt <- rankedAbundance(df, "entity.SampleID", method='q3', naToValue = 0, verbose=F)
+  dt <- rankedAbundance(df, "entity.SampleID", method='q3', naToZero = T, verbose=F)
   expect_equal(nrow(dt), nrow(df))
   expect_s3_class(dt, 'data.table')
   expect_equal(names(dt), paste0('entity.',c('SampleID','Lactobacillus','Snodgrassella','Gilliamella','Frischella','Commensalibacter','unclassified Rhizobiaceae','Bifidobacterium','unclassified Mitochondria','unclassified Chloroplast','Bombella')))
@@ -126,7 +126,7 @@ test_that("rankedAbundanceApp produces an appropriately structured list of compu
   # With NAs
   nNAs <- 20
   df[sample(1:nrow(df), size=nNAs, replace = F), 2] <- NA
-  appResults <- rankedAbundanceApp(df, "entity.SampleID", methods = c('q3', 'median'), naToValue = 0, verbose=F)
+  appResults <- rankedAbundanceApp(df, "entity.SampleID", methods = c('q3', 'median'), naToZero = T, verbose=F)
   expect_equal(length(appResults), 2)
   expect_equal(unique(unlist(lapply(appResults, class))), c('data.table','data.frame'))
   expect_equal(unique(unlist(lapply(appResults, ncol))), 11)


### PR DESCRIPTION
Resolves #10 

See also [veupathUtils PR](https://github.com/VEuPathDB/veupathUtils/pull/4)

## Goal
- add argument that allows user to optionally swap NAs for 0 in the input df's numeric columns. 

## Notes
- I couldn't think of a reasonable situation in which we'd pass a subset of numeric columns to `setNaToValue` when running these apps, so currently the user has no argument in the app functions to specify columns
- Once approved, I'll make the same change in plot.data and then update the data service



