### PR TITLE
Fix 38 stats results as strings

### DIFF
--- a/R/methods-ComputeResult.R
+++ b/R/methods-ComputeResult.R
@@ -86,7 +86,7 @@ setGeneric("writeStatistics",
 setMethod("writeStatistics", signature("ComputeResult"), function(object, pattern = NULL, verbose = c(TRUE, FALSE)) {
   verbose <- veupathUtils::matchArg(verbose)
 
-  outJson <- jsonlite::toJSON(object@statistics, digits = NA) # digits=NA for max precision
+  outJson <- jsonlite::toJSON(lapply(result@statistics, as.character), digits = NA) # digits=NA for max precision
 
   if (is.null(pattern)) { 
     pattern <- object@name

--- a/R/methods-ComputeResult.R
+++ b/R/methods-ComputeResult.R
@@ -86,7 +86,7 @@ setGeneric("writeStatistics",
 setMethod("writeStatistics", signature("ComputeResult"), function(object, pattern = NULL, verbose = c(TRUE, FALSE)) {
   verbose <- veupathUtils::matchArg(verbose)
 
-  outJson <- jsonlite::toJSON(lapply(result@statistics, as.character), digits = NA) # digits=NA for max precision
+  outJson <- jsonlite::toJSON(lapply(object@statistics, as.character), digits = NA) # digits=NA for max precision
 
   if (is.null(pattern)) { 
     pattern <- object@name

--- a/R/methods-ComputeResult.R
+++ b/R/methods-ComputeResult.R
@@ -86,7 +86,10 @@ setGeneric("writeStatistics",
 setMethod("writeStatistics", signature("ComputeResult"), function(object, pattern = NULL, verbose = c(TRUE, FALSE)) {
   verbose <- veupathUtils::matchArg(verbose)
 
-  outJson <- jsonlite::toJSON(lapply(object@statistics, as.character), digits = NA) # digits=NA for max precision
+  # Convert all to character but maintain structure 
+  outObject <- data.frame(lapply(object@statistics, as.character))
+
+  outJson <- jsonlite::toJSON(outObject)
 
   if (is.null(pattern)) { 
     pattern <- object@name

--- a/tests/testthat/test-ComputeResult.R
+++ b/tests/testthat/test-ComputeResult.R
@@ -120,12 +120,14 @@ test_that("ComputeResult writeStatistics returns formatted json.", {
                                            )),
               data = df)
 
-  outJson <- jsonlite::toJSON(result@statistics, digits=NA)
+  # transform to character, just like in the real method
+  outJson <- jsonlite::toJSON(lapply(result@statistics, as.character), digits=NA)
   jsonList <- jsonlite::fromJSON(outJson)
-  expect_equal(nrow(jsonList), nStats)
+  
+  expect_equal(length(jsonList$stat_float), nStats) # Check we still have enough stats
   expect_equal(names(jsonList), c('stat_float','stat_char','stat_with_missing'))
-  expect_equal(unname(unlist(lapply(jsonList,class))), c('numeric','character','numeric'))
-  expect_equal(jsonList$stat_with_missing, result@statistics$stat_with_missing)
-  expect_equal(jsonList$stat_float, result@statistics$stat_float)
+  expect_equal(unname(unlist(lapply(jsonList,class))), c('character','character','character'))
+  expect_equal(jsonList$stat_with_missing, as.character(result@statistics$stat_with_missing))
+  expect_equal(jsonList$stat_float, as.character(result@statistics$stat_float))
 
 })

--- a/tests/testthat/test-ComputeResult.R
+++ b/tests/testthat/test-ComputeResult.R
@@ -121,7 +121,8 @@ test_that("ComputeResult writeStatistics returns formatted json.", {
               data = df)
 
   # transform to character, just like in the real method
-  outJson <- jsonlite::toJSON(lapply(result@statistics, as.character), digits=NA)
+  charObject <- data.frame(lapply(result@statistics, as.character))
+  outJson <- jsonlite::toJSON(charObject)
   jsonList <- jsonlite::fromJSON(outJson)
   
   expect_equal(length(jsonList$stat_float), nStats) # Check we still have enough stats


### PR DESCRIPTION
Resolves #38 

Everything should be a string. That's all there is to it.

Also had to make sure the object passed to toJson is still a data.frame or the json structure gets all messed up.

