### PR TITLE
force continuous bin starts and ends to be numeric and handle nas

### DIFF
--- a/R/class-AbundanceData.R
+++ b/R/class-AbundanceData.R
@@ -42,6 +42,10 @@ check_abundance_data <- function(object) {
         msg <- paste("Samples do not match between the sample metadata and abundance data.")
         errors <- c(errors, msg)
       }
+      if (!identical(sampleMetadata[[record_id_col]], df[[record_id_col]])) {
+        msg <- paste("Samples in the sample metadata are not in the same order as in the abundance data.")
+        errors <- c(errors, msg)
+      }
     }
 
     

--- a/R/method-differentialAbundance.R
+++ b/R/method-differentialAbundance.R
@@ -77,6 +77,7 @@ setMethod("differentialAbundance", signature("AbsoluteAbundanceData", "Comparato
       # So inGroupA is a vector with 0 if the value in comparatorColName is not within any of the group A bins and >0 otherwise.
       lapply(comparator@groupA, print)
       lapply(comparator@groupB, print)
+      print(sampleMetadata[[comparatorColName]])
       inGroupA <- veupathUtils::whichValuesInBinList(sampleMetadata[[comparatorColName]], comparator@groupA)
       inGroupB <- veupathUtils::whichValuesInBinList(sampleMetadata[[comparatorColName]], comparator@groupB)
 

--- a/R/method-differentialAbundance.R
+++ b/R/method-differentialAbundance.R
@@ -75,8 +75,13 @@ setMethod("differentialAbundance", signature("AbsoluteAbundanceData", "Comparato
 
       # Collect all instances where the comparatorColName has values in the bins from each group.
       # So inGroupA is a vector with 0 if the value in comparatorColName is not within any of the group A bins and >0 otherwise.
+      print(comparator@groupA)
+      print(comparator@groupB)
       inGroupA <- veupathUtils::whichValuesInBinList(sampleMetadata[[comparatorColName]], comparator@groupA)
       inGroupB <- veupathUtils::whichValuesInBinList(sampleMetadata[[comparatorColName]], comparator@groupB)
+
+      print(inGroupA)
+      print(inGroupB)
 
       # Eventually move this check to Comparator validation. See #47
       if ((any(inGroupA * inGroupB) > 0)) {

--- a/R/method-differentialAbundance.R
+++ b/R/method-differentialAbundance.R
@@ -75,8 +75,8 @@ setMethod("differentialAbundance", signature("AbsoluteAbundanceData", "Comparato
 
       # Collect all instances where the comparatorColName has values in the bins from each group.
       # So inGroupA is a vector with 0 if the value in comparatorColName is not within any of the group A bins and >0 otherwise.
-      lapply(comparatorVariable@groupA, print)
-      lapply(comparatorVariable@groupB, print)
+      lapply(comparator@groupA, print)
+      lapply(comparator@groupB, print)
       inGroupA <- veupathUtils::whichValuesInBinList(sampleMetadata[[comparatorColName]], comparator@groupA)
       inGroupB <- veupathUtils::whichValuesInBinList(sampleMetadata[[comparatorColName]], comparator@groupB)
 

--- a/R/method-differentialAbundance.R
+++ b/R/method-differentialAbundance.R
@@ -56,14 +56,14 @@ setMethod("differentialAbundance", signature("AbsoluteAbundanceData", "Comparato
     # Subset to only include samples with metadata defined in groupA and groupB
     if (identical(comparator@variable@dataShape@value, "CONTINUOUS")) {
       # Ensure bin starts and ends are numeric
-      comparator@groupA <- veupathUtils::BinList(lapply(comparatorVariable@groupA, function(bin) {
+      comparator@groupA <- veupathUtils::BinList(lapply(comparator@groupA, function(bin) {
         return(veupathUtils::Bin(
           binStart = as.numeric(bin@binStart),
           binEnd = as.numeric(bin@binEnd),
           binLabel = bin@binLabel
         ))
       }))
-      comparator@groupB <- veupathUtils::BinList(lapply(comparatorVariable@groupB, function(bin) {
+      comparator@groupB <- veupathUtils::BinList(lapply(comparator@groupB, function(bin) {
         return(veupathUtils::Bin(
           binStart = as.numeric(bin@binStart),
           binEnd = as.numeric(bin@binEnd),

--- a/R/method-differentialAbundance.R
+++ b/R/method-differentialAbundance.R
@@ -55,6 +55,21 @@ setMethod("differentialAbundance", signature("AbsoluteAbundanceData", "Comparato
 
     # Subset to only include samples with metadata defined in groupA and groupB
     if (identical(comparator@variable@dataShape@value, "CONTINUOUS")) {
+      # Ensure bin starts and ends are numeric
+      comparator@groupA <- veupathUtils::BinList(lapply(comparatorVariable@groupA, function(bin) {
+        return(veupathUtils::Bin(
+          binStart = as.numeric(bin@binStart),
+          binEnd = as.numeric(bin@binEnd),
+          binLabel = bin@binLabel
+        ))
+      }))
+      comparator@groupB <- veupathUtils::BinList(lapply(comparatorVariable@groupB, function(bin) {
+        return(veupathUtils::Bin(
+          binStart = as.numeric(bin@binStart),
+          binEnd = as.numeric(bin@binEnd),
+          binLabel = bin@binLabel
+        ))
+      }))
       # We need to turn the numeric comparison variable into a categorical one with those values
       # that fall within group A or group B bins marked with some string we know.
 

--- a/R/method-differentialAbundance.R
+++ b/R/method-differentialAbundance.R
@@ -75,8 +75,8 @@ setMethod("differentialAbundance", signature("AbsoluteAbundanceData", "Comparato
 
       # Collect all instances where the comparatorColName has values in the bins from each group.
       # So inGroupA is a vector with 0 if the value in comparatorColName is not within any of the group A bins and >0 otherwise.
-      print(comparator@groupA)
-      print(comparator@groupB)
+      lapply(comparatorVariable@groupA, print)
+      lapply(comparatorVariable@groupB, print)
       inGroupA <- veupathUtils::whichValuesInBinList(sampleMetadata[[comparatorColName]], comparator@groupA)
       inGroupB <- veupathUtils::whichValuesInBinList(sampleMetadata[[comparatorColName]], comparator@groupB)
 

--- a/R/method-differentialAbundance.R
+++ b/R/method-differentialAbundance.R
@@ -65,21 +65,12 @@ setMethod("differentialAbundance", signature("AbsoluteAbundanceData", "Comparato
 
     # Subset to only include samples with metadata defined in groupA and groupB
     if (identical(comparator@variable@dataShape@value, "CONTINUOUS")) {
+      
       # Ensure bin starts and ends are numeric
-      comparator@groupA <- veupathUtils::BinList(lapply(comparator@groupA, function(bin) {
-        return(veupathUtils::Bin(
-          binStart = as.numeric(bin@binStart),
-          binEnd = as.numeric(bin@binEnd),
-          binLabel = bin@binLabel
-        ))
-      }))
-      comparator@groupB <- veupathUtils::BinList(lapply(comparator@groupB, function(bin) {
-        return(veupathUtils::Bin(
-          binStart = as.numeric(bin@binStart),
-          binEnd = as.numeric(bin@binEnd),
-          binLabel = bin@binLabel
-        ))
-      }))
+      comparator@groupA <- veupathUtils::as.numeric(comparator@groupA)
+      comparator@groupB <- veupathUtils::as.numeric(comparator@groupB)
+
+
       # We need to turn the numeric comparison variable into a categorical one with those values
       # that fall within group A or group B bins marked with some string we know.
 

--- a/R/method-differentialAbundance.R
+++ b/R/method-differentialAbundance.R
@@ -52,6 +52,16 @@ setMethod("differentialAbundance", signature("AbsoluteAbundanceData", "Comparato
       veupathUtils::logWithTime("Replaced NAs with 0", verbose)
     }
 
+    # Remove samples with NA from data and metadata
+    if (any(is.na(sampleMetadata[[comparatorColName]]))) {
+      veupathUtils::logWithTime("Found NAs in comparator variable. Removing these samples.", verbose)
+      samplesWithData <- which(!is.na(sampleMetadata[[comparatorColName]]))
+      # Keep samples with data. Recall the AbundanceData object requires samples to be in the same order
+      # in both the data and metadata
+      sampleMetadata <- sampleMetadata[samplesWithData, ]
+      df <- df[samplesWithData, ]
+    }
+
 
     # Subset to only include samples with metadata defined in groupA and groupB
     if (identical(comparator@variable@dataShape@value, "CONTINUOUS")) {
@@ -75,14 +85,8 @@ setMethod("differentialAbundance", signature("AbsoluteAbundanceData", "Comparato
 
       # Collect all instances where the comparatorColName has values in the bins from each group.
       # So inGroupA is a vector with 0 if the value in comparatorColName is not within any of the group A bins and >0 otherwise.
-      lapply(comparator@groupA, print)
-      lapply(comparator@groupB, print)
-      print(sampleMetadata[[comparatorColName]])
       inGroupA <- veupathUtils::whichValuesInBinList(sampleMetadata[[comparatorColName]], comparator@groupA)
       inGroupB <- veupathUtils::whichValuesInBinList(sampleMetadata[[comparatorColName]], comparator@groupB)
-
-      print(inGroupA)
-      print(inGroupB)
 
       # Eventually move this check to Comparator validation. See #47
       if ((any(inGroupA * inGroupB) > 0)) {

--- a/R/method-differentialAbundance.R
+++ b/R/method-differentialAbundance.R
@@ -125,7 +125,7 @@ setMethod("differentialAbundance", signature("AbsoluteAbundanceData", "Comparato
     if (!length(keepSamples)) {
       stop("No samples remain after subsetting based on the comparator variable.")
     }
-    veupathUtils::logWithTime(paste0("Found ",length(keepSamples)," samples with ", comparatorColName, "in either groupA or groupB. The calculation will continue with only these samples."), verbose)
+    veupathUtils::logWithTime(paste0("Found ",length(keepSamples)," samples with the value of ", comparatorColName, "in either groupA or groupB. The calculation will continue with only these samples."), verbose)
 
     # Subset the abundance data based on the kept samples
     df <- df[get(recordIdColumn) %in% keepSamples, ]

--- a/tests/testthat/test-Comparator.R
+++ b/tests/testthat/test-Comparator.R
@@ -63,10 +63,10 @@ test_that('Comparator validation works', {
 
 test_that("getGroupLabels returns bin labels", {
   # With a continuous variable
-  bin1 <- veupathUtils::Bin(binStart=2, binEnd=3, binLabel="[2, 3)")
-  bin2 <- veupathUtils::Bin(binStart=3, binEnd=4, binLabel="[3, 4)")
-  bin3 <- veupathUtils::Bin(binStart=4, binEnd=5, binLabel="[4, 5)")
-  bin4 <- veupathUtils::Bin(binStart=5, binEnd=6, binLabel="[5, 6)")
+  bin1 <- veupathUtils::Bin(binStart='2', binEnd='3', binLabel="[2, 3)")
+  bin2 <- veupathUtils::Bin(binStart='3', binEnd='4', binLabel="[3, 4)")
+  bin3 <- veupathUtils::Bin(binStart='4', binEnd='5', binLabel="[4, 5)")
+  bin4 <- veupathUtils::Bin(binStart='5', binEnd='6', binLabel="[5, 6)")
 
   groupABins <- veupathUtils::BinList(S4Vectors::SimpleList(c(bin1, bin2)))
   groupBBins <- veupathUtils::BinList(S4Vectors::SimpleList(c(bin3, bin4)))

--- a/tests/testthat/test-ComputeResult.R
+++ b/tests/testthat/test-ComputeResult.R
@@ -102,7 +102,7 @@ test_that("ComputeResult writeMeta method returns well formatted json", {
   jsonlist <- jsonlite::fromJSON(veupathUtils::toJSON(result@computedVariableMetadata))
 
   expect_equal(names(jsonlist), 'variables')
-  expect_equal(names(jsonlist$variables), c("variableClass","variableSpec","plotReference","displayName","displayRangeMin","displayRangeMax","dataType","dataShape","isCollection","imputeZero"))
+  expect_equal(names(jsonlist$variables), c("variableClass","variableSpec","plotReference","displayName","displayRangeMin","displayRangeMax","dataType","dataShape","isCollection","imputeZero","hasStudyDependentVocabulary"))
 })
 
 

--- a/tests/testthat/test-differentialAbundance.R
+++ b/tests/testthat/test-differentialAbundance.R
@@ -98,10 +98,10 @@ test_that('differentialAbundance returns a correctly formatted data.table', {
 
 
   # With a continuous variable
-  bin1 <- veupathUtils::Bin(binStart=2, binEnd=3, binLabel="[2, 3)")
-  bin2 <- veupathUtils::Bin(binStart=3, binEnd=4, binLabel="[3, 4)")
-  bin3 <- veupathUtils::Bin(binStart=4, binEnd=5, binLabel="[4, 5)")
-  bin4 <- veupathUtils::Bin(binStart=5, binEnd=6, binLabel="[5, 6)")
+  bin1 <- veupathUtils::Bin(binStart='2', binEnd='3', binLabel="[2, 3)")
+  bin2 <- veupathUtils::Bin(binStart='3', binEnd='4', binLabel="[3, 4)")
+  bin3 <- veupathUtils::Bin(binStart='4', binEnd='5', binLabel="[4, 5)")
+  bin4 <- veupathUtils::Bin(binStart='5', binEnd='6', binLabel="[5, 6)")
 
   groupABins <- veupathUtils::BinList(S4Vectors::SimpleList(c(bin1, bin2)))
   groupBBins <- veupathUtils::BinList(S4Vectors::SimpleList(c(bin3, bin4)))


### PR DESCRIPTION
Found that microbiomeComputations expects those bin starts and ends to be numeric but the data we receive has them as strings! So, ensure that if the comparator var is continuous then we coerce the bin starts and ends to numeric in order to perform all the rest of the logic.

Integration test: passed!

This PR does the following:
1. uses the new `as.numeric` function from veupathUtils to coerce bin starts and ends to be numeric when it's a continuous variable
2. removes any NAs found in the comparator variable _before_ getting into the computation. I found having this step right at the top instead of inside the conditional easier to read and to check.
