### PR TITLE
Fix the as.numeric issue in diff abund

### DIFF
--- a/R/method-differentialAbundance.R
+++ b/R/method-differentialAbundance.R
@@ -67,8 +67,8 @@ setMethod("differentialAbundance", signature("AbsoluteAbundanceData", "Comparato
     if (identical(comparator@variable@dataShape@value, "CONTINUOUS")) {
       
       # Ensure bin starts and ends are numeric
-      comparator@groupA <- veupathUtils::as.numeric(comparator@groupA)
-      comparator@groupB <- veupathUtils::as.numeric(comparator@groupB)
+      comparator@groupA <- as.numeric(comparator@groupA)
+      comparator@groupB <- as.numeric(comparator@groupB)
 
 
       # We need to turn the numeric comparison variable into a categorical one with those values


### PR DESCRIPTION
Originally were getting the issue "as.numeric is not an exported function from veupathUtils" which made no sense to me because yes it is. But i guess becasue we're just adding to a generic, veupathUtils doesn't really "own" the method. That was a new concept to me!

All working well now :) 