### PR TITLE
handle empty metadata slot nicely

### DIFF
--- a/R/class-AbundanceData.R
+++ b/R/class-AbundanceData.R
@@ -41,7 +41,7 @@ check_abundance_data <- function(object) {
         errors <- c(errors, msg)
       }
       if (setequal(names(sampleMetadata@data), c(record_id_col, ancestor_id_cols))) {
-        msg <- paste("The sample metadata only contains record ID and ancestor ID columns.")
+        msg <- paste("The sample metadata only contains record ID and ancestor ID columns but no metadata variables.")
         errors <- c(errors, msg)
       }
     }

--- a/R/class-AbundanceData.R
+++ b/R/class-AbundanceData.R
@@ -40,9 +40,11 @@ check_abundance_data <- function(object) {
         msg <- paste("Samples in the sample metadata are not in the same order as in the abundance data.")
         errors <- c(errors, msg)
       }
+      if (setequal(names(sampleMetadata@data), c(record_id_col, ancestor_id_cols))) {
+        msg <- paste("The sample metadata only contains record ID and ancestor ID columns.")
+        errors <- c(errors, msg)
+      }
     }
-
-    
 
     return(if (length(errors) == 0) TRUE else errors)
 }

--- a/R/methods-AbundanceData.R
+++ b/R/methods-AbundanceData.R
@@ -70,6 +70,9 @@ setMethod("getSampleMetadata", signature("AbundanceData"), function(object, asCo
   if (!includeIds) {
     allIdColumns <- c(object@recordIdColumn, object@ancestorIdColumns)
     dt <- dt[, -..allIdColumns]
+    if (nrow(dt) == 0) {
+      warning("AbundanceData object has no sample metadata. Returning empty data.table from getSampleMetadata.")
+    }
   }
 
   return(dt)

--- a/R/methods-AbundanceData.R
+++ b/R/methods-AbundanceData.R
@@ -70,9 +70,6 @@ setMethod("getSampleMetadata", signature("AbundanceData"), function(object, asCo
   if (!includeIds) {
     allIdColumns <- c(object@recordIdColumn, object@ancestorIdColumns)
     dt <- dt[, -..allIdColumns]
-    if (nrow(dt) == 0) {
-      warning("AbundanceData object has no sample metadata. Returning empty data.table from getSampleMetadata.")
-    }
   }
 
   return(dt)

--- a/tests/testthat/test-AbundanceData.R
+++ b/tests/testthat/test-AbundanceData.R
@@ -40,4 +40,19 @@ test_that('AbundanceData validation works', {
   expect_equal(testing@recordIdColumn, 'entity.SampleID')
   expect_equal(testing@ancestorIdColumns, character(0))
   expect_true(testing@imputeZero)
+
+
+  sampleMetadata <- microbiomeComputations::SampleMetadata(
+    data = df[, 'entity.SampleID', with=F],
+    recordIdColumn = 'entity.SampleID'
+  )
+
+  expect_error(
+    microbiomeComputations::AbundanceData(
+      data = df,
+      sampleMetadata = sampleMetadata,
+      recordIdColumn = 'entity.SampleID'
+    )
+  )
+
 })


### PR DESCRIPTION
ive added a warning, but would we prefer to handle this in the AbundanceData validation and err? it seems a bit heavy handed, but then the warning might be too subtle?

either way i think in practice we wont see this any longer once we are graying the correlation app for studies without metadata, but id still like better logging